### PR TITLE
Add browser and MCP init subcommands

### DIFF
--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -2,7 +2,7 @@ import typer
 from dotenv import load_dotenv
 
 from .docs import docs_app
-from .init_command import init
+from .init_command import init, init_browser, init_mcp
 from .run_commands import run_app
 from .setup_commands import setup_mcp_command
 from .tasks import tasks_app
@@ -15,9 +15,33 @@ cli_app.add_typer(tasks_app, name="tasks")
 cli_app.add_typer(docs_app, name="docs")
 setup_app = typer.Typer()
 cli_app.add_typer(setup_app, name="setup")
+init_app = typer.Typer(invoke_without_command=True)
+cli_app.add_typer(init_app, name="init")
 
 setup_app.command(name="mcp")(setup_mcp_command)
-cli_app.command(name="init")(init)
+
+
+@init_app.callback()
+def init_callback(
+    ctx: typer.Context,
+    no_postgres: bool = typer.Option(False, "--no-postgres", help="Skip starting PostgreSQL container"),
+) -> None:
+    """Run full initialization when no subcommand is provided."""
+    if ctx.invoked_subcommand is None:
+        init(no_postgres=no_postgres)
+
+
+@init_app.command(name="browser")
+def init_browser_command() -> None:
+    """Initialize only the browser configuration."""
+    init_browser()
+
+
+@init_app.command(name="mcp")
+def init_mcp_command() -> None:
+    """Initialize only the MCP server configuration."""
+    init_mcp()
+
 
 if __name__ == "__main__":  # pragma: no cover - manual CLI invocation
     load_dotenv()

--- a/skyvern/cli/init_command.py
+++ b/skyvern/cli/init_command.py
@@ -122,3 +122,28 @@ def init(
         console.print("\n🎉 [bold green]Skyvern setup complete![/bold green]")
         console.print("[bold]To start using Skyvern, run:[/bold]")
         console.print(Padding("skyvern run server", (1, 4), style="reverse green"))
+
+
+def init_browser() -> None:
+    """Initialize only the browser configuration and install Chromium."""
+    console.print("\n[bold blue]Configuring browser settings...[/bold blue]")
+    browser_type, browser_location, remote_debugging_url = setup_browser_config()
+    update_or_add_env_var("BROWSER_TYPE", browser_type)
+    if browser_location:
+        update_or_add_env_var("CHROME_EXECUTABLE_PATH", browser_location)
+    if remote_debugging_url:
+        update_or_add_env_var("BROWSER_REMOTE_DEBUGGING_URL", remote_debugging_url)
+    console.print("✅ [green]Browser configuration complete.[/green]")
+
+    console.print("\n⬇️ [bold blue]Installing Chromium browser...[/bold blue]")
+    with Progress(
+        SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True, console=console
+    ) as progress:
+        progress.add_task("[bold blue]Downloading Chromium, this may take a moment...", total=None)
+        subprocess.run(["playwright", "install", "chromium"], check=True)
+    console.print("✅ [green]Chromium installation complete.[/green]")
+
+
+def init_mcp() -> None:
+    """Initialize only the MCP server configuration."""
+    setup_mcp()


### PR DESCRIPTION
## Summary
- support separate browser and mcp init commands
- expose them through `skyvern init browser` and `skyvern init mcp`

## Testing
- `ruff check skyvern/cli/commands.py skyvern/cli/init_command.py`
- `mypy skyvern/cli/commands.py skyvern/cli/init_command.py`
