### PR TITLE
Remove MCP setup CLI commands

### DIFF
--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -2,9 +2,8 @@ import typer
 from dotenv import load_dotenv
 
 from .docs import docs_app
-from .init_command import init, init_browser, init_mcp
+from .init_command import init, init_browser
 from .run_commands import run_app
-from .setup_commands import setup_mcp_command
 from .tasks import tasks_app
 from .workflow import workflow_app
 
@@ -13,12 +12,8 @@ cli_app.add_typer(run_app, name="run")
 cli_app.add_typer(workflow_app, name="workflow")
 cli_app.add_typer(tasks_app, name="tasks")
 cli_app.add_typer(docs_app, name="docs")
-setup_app = typer.Typer()
-cli_app.add_typer(setup_app, name="setup")
 init_app = typer.Typer(invoke_without_command=True)
 cli_app.add_typer(init_app, name="init")
-
-setup_app.command(name="mcp")(setup_mcp_command)
 
 
 @init_app.callback()
@@ -35,12 +30,6 @@ def init_callback(
 def init_browser_command() -> None:
     """Initialize only the browser configuration."""
     init_browser()
-
-
-@init_app.command(name="mcp")
-def init_mcp_command() -> None:
-    """Initialize only the MCP server configuration."""
-    init_mcp()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual CLI invocation

--- a/skyvern/cli/init_command.py
+++ b/skyvern/cli/init_command.py
@@ -142,8 +142,3 @@ def init_browser() -> None:
         progress.add_task("[bold blue]Downloading Chromium, this may take a moment...", total=None)
         subprocess.run(["playwright", "install", "chromium"], check=True)
     console.print("✅ [green]Chromium installation complete.[/green]")
-
-
-def init_mcp() -> None:
-    """Initialize only the MCP server configuration."""
-    setup_mcp()

--- a/skyvern/cli/setup_commands.py
+++ b/skyvern/cli/setup_commands.py
@@ -1,6 +1,0 @@
-from .mcp import setup_mcp
-
-
-def setup_mcp_command() -> None:
-    """Wrapper command to configure the MCP server."""
-    setup_mcp()


### PR DESCRIPTION
## Summary
- remove setup CLI entrypoints
- drop init MCP command wrapper

## Testing
- `ruff format skyvern/cli/commands.py skyvern/cli/init_command.py`
- `ruff check skyvern/cli/commands.py skyvern/cli/init_command.py`
- `pytest -q` *(fails: command not found)*