### PR TITLE
Enable docs command

### DIFF
--- a/skyvern/cli/docs.py
+++ b/skyvern/cli/docs.py
@@ -1,13 +1,28 @@
 """Documentation-related CLI helpers."""
 
+import webbrowser
+
 import typer
+from rich.panel import Panel
 
 from .console import console
 
-docs_app = typer.Typer()
+DOCS_URL = "https://docs.skyvern.com"
+
+docs_app = typer.Typer(invoke_without_command=True)
 
 
-@docs_app.command()
-def placeholder() -> None:
-    """Placeholder command for documentation actions."""
-    console.print("Documentation commands are not yet implemented.")
+@docs_app.callback()
+def docs_callback(ctx: typer.Context) -> None:
+    """Open the Skyvern documentation in a browser."""
+    if ctx.invoked_subcommand is None:
+        console.print(
+            Panel(
+                f"[bold blue]Opening Skyvern docs at [link={DOCS_URL}]{DOCS_URL}[/link][/bold blue]",
+                border_style="cyan",
+            )
+        )
+        try:
+            webbrowser.open(DOCS_URL)
+        except Exception as exc:  # pragma: no cover - CLI safeguard
+            console.print(f"[red]Failed to open documentation: {exc}[/red]")


### PR DESCRIPTION
## Summary
- make `skyvern docs` open the online documentation

## Testing
- `ruff check skyvern/cli/docs.py`
- `ruff format skyvern/cli/docs.py`
- `isort skyvern/cli/docs.py`
- `mypy skyvern/cli/docs.py`
- `pre-commit run --files skyvern/cli/docs.py` *(fails: command not found)*