### PR TITLE
Add CLI status commands

### DIFF
--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -4,15 +4,34 @@ from dotenv import load_dotenv
 from .docs import docs_app
 from .init_command import init, init_browser
 from .run_commands import run_app
+from .status import status_app
 from .tasks import tasks_app
 from .workflow import workflow_app
 
-cli_app = typer.Typer()
-cli_app.add_typer(run_app, name="run")
-cli_app.add_typer(workflow_app, name="workflow")
-cli_app.add_typer(tasks_app, name="tasks")
-cli_app.add_typer(docs_app, name="docs")
-init_app = typer.Typer(invoke_without_command=True)
+cli_app = typer.Typer(
+    help=(
+        """[bold]Skyvern CLI[/bold]\nManage and run your local Skyvern environment."""
+    ),
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+cli_app.add_typer(
+    run_app,
+    name="run",
+    help="Run Skyvern services like the API server, UI, and MCP.",
+)
+cli_app.add_typer(
+    workflow_app, name="workflow", help="Workflow management commands."
+)
+cli_app.add_typer(tasks_app, name="tasks", help="Task management commands.")
+cli_app.add_typer(docs_app, name="docs", help="Open Skyvern documentation.")
+cli_app.add_typer(
+    status_app, name="status", help="Check if Skyvern services are running."
+)
+init_app = typer.Typer(
+    invoke_without_command=True,
+    help="Interactively configure Skyvern and its dependencies.",
+)
 cli_app.add_typer(init_app, name="init")
 
 

--- a/skyvern/cli/docs.py
+++ b/skyvern/cli/docs.py
@@ -9,7 +9,10 @@ from .console import console
 
 DOCS_URL = "https://docs.skyvern.com"
 
-docs_app = typer.Typer(invoke_without_command=True)
+docs_app = typer.Typer(
+    invoke_without_command=True,
+    help="Open Skyvern documentation in your browser.",
+)
 
 
 @docs_app.callback()

--- a/skyvern/cli/run_commands.py
+++ b/skyvern/cli/run_commands.py
@@ -16,7 +16,9 @@ from skyvern.utils import detect_os
 
 from .console import console
 
-run_app = typer.Typer()
+run_app = typer.Typer(
+    help="Commands to run Skyvern services such as the API server or UI."
+)
 
 mcp = FastMCP("Skyvern")
 

--- a/skyvern/cli/status.py
+++ b/skyvern/cli/status.py
@@ -1,0 +1,55 @@
+import typer
+from rich.panel import Panel
+
+from .console import console
+from .run_commands import get_pids_on_port
+
+status_app = typer.Typer(help="Check status of Skyvern components")
+
+
+def _print_status(is_running: bool, name: str, start_cmd: str) -> None:
+    if is_running:
+        console.print(f"✅ [green]{name} is running.[/green]")
+    else:
+        console.print(
+            Panel(
+                f"[red]{name} is not running.[/red]\nRun [bold]{start_cmd}[/bold] to start it.",
+                border_style="red",
+            )
+        )
+
+
+def _check_port(port: int) -> bool:
+    return bool(get_pids_on_port(port))
+
+
+@status_app.command()
+def all() -> None:
+    """Show status for API server, UI, and database."""
+    console.print("[bold blue]Skyvern component status:[/bold blue]")
+    database()
+    server()
+    ui()
+
+
+@status_app.command()
+def server() -> None:
+    """Check if the Skyvern API server is running."""
+    from skyvern.config import settings
+
+    is_running = _check_port(settings.PORT)
+    _print_status(is_running, "API server", "skyvern run server")
+
+
+@status_app.command()
+def ui() -> None:
+    """Check if the Skyvern UI server is running."""
+    is_running = _check_port(8080)
+    _print_status(is_running, "UI server", "skyvern run ui")
+
+
+@status_app.command()
+def database() -> None:
+    """Check if PostgreSQL is running."""
+    is_running = _check_port(5432)
+    _print_status(is_running, "PostgreSQL", "skyvern init --no-postgres false")

--- a/skyvern/cli/tasks.py
+++ b/skyvern/cli/tasks.py
@@ -4,7 +4,7 @@ import typer
 
 from .console import console
 
-tasks_app = typer.Typer()
+tasks_app = typer.Typer(help="Manage Skyvern tasks and operations.")
 
 
 @tasks_app.command()

--- a/skyvern/cli/workflow.py
+++ b/skyvern/cli/workflow.py
@@ -4,7 +4,7 @@ import typer
 
 from .console import console
 
-workflow_app = typer.Typer()
+workflow_app = typer.Typer(help="Manage Skyvern workflows.")
 
 
 @workflow_app.command()


### PR DESCRIPTION
## Summary
- improve CLI help descriptions so all commands show in `skyvern --help`
- add run, workflow, tasks, docs, status subcommand help

## Testing
- `ruff check skyvern/cli/commands.py skyvern/cli/run_commands.py skyvern/cli/docs.py skyvern/cli/tasks.py skyvern/cli/workflow.py skyvern/cli/status.py`
- `pre-commit run --files skyvern/cli/commands.py skyvern/cli/run_commands.py skyvern/cli/docs.py skyvern/cli/tasks.py skyvern/cli/workflow.py skyvern/cli/status.py` *(fails: command not found)*