### PR TITLE
Add API key usage fix and handle empty parameters

### DIFF
--- a/skyvern/cli/workflow.py
+++ b/skyvern/cli/workflow.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Optional
 
+import os
+
 import typer
 from dotenv import load_dotenv
 from rich.panel import Panel
@@ -18,23 +20,35 @@ from .console import console
 workflow_app = typer.Typer(help="Manage Skyvern workflows.")
 
 
-def _get_client() -> Skyvern:
+@workflow_app.callback()
+def workflow_callback(
+    ctx: typer.Context,
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="Skyvern API key",
+        envvar="SKYVERN_API_KEY",
+    ),
+) -> None:
+    """Store the provided API key in the Typer context."""
+    ctx.obj = {"api_key": api_key}
+
+
+def _get_client(api_key: Optional[str] = None) -> Skyvern:
     """Instantiate a Skyvern SDK client using environment variables."""
     load_dotenv()
     load_dotenv(".env")
-    return Skyvern(base_url=settings.SKYVERN_BASE_URL, api_key=settings.SKYVERN_API_KEY)
+    key = api_key or os.getenv("SKYVERN_API_KEY") or settings.SKYVERN_API_KEY
+    return Skyvern(base_url=settings.SKYVERN_BASE_URL, api_key=key)
 
 
 @workflow_app.command("start")
 def start_workflow(
+    ctx: typer.Context,
     workflow_id: str = typer.Argument(..., help="Workflow permanent ID"),
-    parameters: str = typer.Option(
-        "{}", "--parameters", "-p", help="JSON parameters for the workflow"
-    ),
+    parameters: str = typer.Option("{}", "--parameters", "-p", help="JSON parameters for the workflow"),
     title: Optional[str] = typer.Option(None, "--title", help="Title for the workflow run"),
-    max_steps: Optional[int] = typer.Option(
-        None, "--max-steps", help="Override the workflow max steps"
-    ),
+    max_steps: Optional[int] = typer.Option(None, "--max-steps", help="Override the workflow max steps"),
 ) -> None:
     """Dispatch a workflow run."""
     try:
@@ -43,10 +57,10 @@ def start_workflow(
         console.print(f"[red]Invalid JSON for parameters: {parameters}[/red]")
         raise typer.Exit(code=1)
 
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     run_resp = client.agent.run_workflow(
         workflow_id=workflow_id,
-        parameters=params_dict or None,
+        parameters=params_dict,
         title=title,
         max_steps_override=max_steps,
     )
@@ -59,16 +73,22 @@ def start_workflow(
 
 
 @workflow_app.command("stop")
-def stop_workflow(run_id: str = typer.Argument(..., help="ID of the workflow run")) -> None:
+def stop_workflow(
+    ctx: typer.Context,
+    run_id: str = typer.Argument(..., help="ID of the workflow run"),
+) -> None:
     """Cancel a running workflow."""
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     client.agent.cancel_run(run_id=run_id)
     console.print(Panel(f"Stop signal sent for run {run_id}", border_style="red"))
 
 
 @workflow_app.command("status")
-def workflow_status(run_id: str = typer.Argument(..., help="ID of the workflow run")) -> None:
+def workflow_status(
+    ctx: typer.Context,
+    run_id: str = typer.Argument(..., help="ID of the workflow run"),
+) -> None:
     """Retrieve status information for a workflow run."""
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     run = client.agent.get_run(run_id=run_id)
     console.print(Panel(run.model_dump_json(indent=2), border_style="cyan"))


### PR DESCRIPTION
## Summary
- fix parameters argument when starting a workflow so empty dicts are sent correctly
- keep API key option and context storage for workflow CLI

## Testing
- `ruff check skyvern/cli/workflow.py`
- `ruff format skyvern/cli/workflow.py`