### PR TITLE
Add workflow listing and task management

### DIFF
--- a/skyvern/cli/tasks.py
+++ b/skyvern/cli/tasks.py
@@ -1,13 +1,63 @@
 """Task-related CLI helpers."""
 
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
 import typer
+from dotenv import load_dotenv
+from rich.panel import Panel
+
+from skyvern.client import Skyvern
+from skyvern.config import settings
 
 from .console import console
+
 
 tasks_app = typer.Typer(help="Manage Skyvern tasks and operations.")
 
 
-@tasks_app.command()
-def placeholder() -> None:
-    """Placeholder command for task management."""
-    console.print("Task operations are not yet implemented.")
+@tasks_app.callback()
+def tasks_callback(
+    ctx: typer.Context,
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="Skyvern API key",
+        envvar="SKYVERN_API_KEY",
+    ),
+) -> None:
+    """Store API key in Typer context."""
+    ctx.obj = {"api_key": api_key}
+
+
+def _get_client(api_key: Optional[str] = None) -> Skyvern:
+    """Instantiate a Skyvern SDK client using environment variables."""
+    load_dotenv()
+    load_dotenv(".env")
+    key = api_key or os.getenv("SKYVERN_API_KEY") or settings.SKYVERN_API_KEY
+    return Skyvern(base_url=settings.SKYVERN_BASE_URL, api_key=key)
+
+
+def _list_workflow_tasks(client: Skyvern, run_id: str) -> list[dict]:
+    """Return tasks for the given workflow run."""
+    resp = client.agent._client_wrapper.httpx_client.request(
+        "api/v1/tasks",
+        method="GET",
+        params={"workflow_run_id": run_id, "page_size": 100, "page": 1},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+@tasks_app.command("list")
+def list_tasks(
+    ctx: typer.Context,
+    workflow_run_id: str = typer.Option(..., "--workflow-run-id", "-r", help="Workflow run ID"),
+) -> None:
+    """List tasks for a workflow run."""
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
+    tasks = _list_workflow_tasks(client, workflow_run_id)
+    console.print(Panel(json.dumps(tasks, indent=2), border_style="cyan"))

--- a/skyvern/cli/workflow.py
+++ b/skyvern/cli/workflow.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Optional
 
+import os
+
 import typer
 from dotenv import load_dotenv
 from rich.panel import Panel
@@ -13,28 +15,41 @@ from skyvern.client import Skyvern
 from skyvern.config import settings
 
 from .console import console
+from .tasks import _list_workflow_tasks
 
 
 workflow_app = typer.Typer(help="Manage Skyvern workflows.")
 
 
-def _get_client() -> Skyvern:
+@workflow_app.callback()
+def workflow_callback(
+    ctx: typer.Context,
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="Skyvern API key",
+        envvar="SKYVERN_API_KEY",
+    ),
+) -> None:
+    """Store the provided API key in the Typer context."""
+    ctx.obj = {"api_key": api_key}
+
+
+def _get_client(api_key: Optional[str] = None) -> Skyvern:
     """Instantiate a Skyvern SDK client using environment variables."""
     load_dotenv()
     load_dotenv(".env")
-    return Skyvern(base_url=settings.SKYVERN_BASE_URL, api_key=settings.SKYVERN_API_KEY)
+    key = api_key or os.getenv("SKYVERN_API_KEY") or settings.SKYVERN_API_KEY
+    return Skyvern(base_url=settings.SKYVERN_BASE_URL, api_key=key)
 
 
 @workflow_app.command("start")
 def start_workflow(
+    ctx: typer.Context,
     workflow_id: str = typer.Argument(..., help="Workflow permanent ID"),
-    parameters: str = typer.Option(
-        "{}", "--parameters", "-p", help="JSON parameters for the workflow"
-    ),
+    parameters: str = typer.Option("{}", "--parameters", "-p", help="JSON parameters for the workflow"),
     title: Optional[str] = typer.Option(None, "--title", help="Title for the workflow run"),
-    max_steps: Optional[int] = typer.Option(
-        None, "--max-steps", help="Override the workflow max steps"
-    ),
+    max_steps: Optional[int] = typer.Option(None, "--max-steps", help="Override the workflow max steps"),
 ) -> None:
     """Dispatch a workflow run."""
     try:
@@ -43,7 +58,7 @@ def start_workflow(
         console.print(f"[red]Invalid JSON for parameters: {parameters}[/red]")
         raise typer.Exit(code=1)
 
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     run_resp = client.agent.run_workflow(
         workflow_id=workflow_id,
         parameters=params_dict or None,
@@ -59,16 +74,44 @@ def start_workflow(
 
 
 @workflow_app.command("stop")
-def stop_workflow(run_id: str = typer.Argument(..., help="ID of the workflow run")) -> None:
+def stop_workflow(
+    ctx: typer.Context,
+    run_id: str = typer.Argument(..., help="ID of the workflow run"),
+) -> None:
     """Cancel a running workflow."""
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     client.agent.cancel_run(run_id=run_id)
     console.print(Panel(f"Stop signal sent for run {run_id}", border_style="red"))
 
 
 @workflow_app.command("status")
-def workflow_status(run_id: str = typer.Argument(..., help="ID of the workflow run")) -> None:
+def workflow_status(
+    ctx: typer.Context,
+    run_id: str = typer.Argument(..., help="ID of the workflow run"),
+    tasks: bool = typer.Option(False, "--tasks", help="Show task executions"),
+) -> None:
     """Retrieve status information for a workflow run."""
-    client = _get_client()
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
     run = client.agent.get_run(run_id=run_id)
     console.print(Panel(run.model_dump_json(indent=2), border_style="cyan"))
+    if tasks:
+        task_list = _list_workflow_tasks(client, run_id)
+        console.print(Panel(json.dumps(task_list, indent=2), border_style="magenta"))
+
+
+@workflow_app.command("list")
+def list_workflows(
+    ctx: typer.Context,
+    page: int = typer.Option(1, "--page", help="Page number"),
+    page_size: int = typer.Option(10, "--page-size", help="Number of workflows to return"),
+    template: bool = typer.Option(False, "--template", help="List template workflows"),
+) -> None:
+    """List workflows for the organization."""
+    client = _get_client(ctx.obj.get("api_key") if ctx.obj else None)
+    resp = client.agent._client_wrapper.httpx_client.request(
+        "api/v1/workflows",
+        method="GET",
+        params={"page": page, "page_size": page_size, "template": template},
+    )
+    resp.raise_for_status()
+    console.print(Panel(json.dumps(resp.json(), indent=2), border_style="cyan"))


### PR DESCRIPTION
## Summary
- add task management helpers with API key support
- show tasks for a workflow run via `--tasks`
- implement `workflow list` command to list workflow definitions

## Testing
- `ruff check skyvern/cli/workflow.py skyvern/cli/tasks.py`
- `ruff format skyvern/cli/workflow.py skyvern/cli/tasks.py`
