### PR TITLE
Simplify status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ This quickstart guide will walk you through getting Skyvern up and running on yo
   skyvern run ui
   ```
 
-5. **Run task**
+5. **Check component status**
+
+  ```bash
+  skyvern status
+  ```
+
+6. **Run task**
 
   Run a skyvern task locally:
   ```python

--- a/skyvern/cli/status.py
+++ b/skyvern/cli/status.py
@@ -1,55 +1,49 @@
+import os
+import socket
 import typer
-from rich.panel import Panel
+from rich.table import Table
 
 from .console import console
-from .run_commands import get_pids_on_port
 
-status_app = typer.Typer(help="Check status of Skyvern components")
-
-
-def _print_status(is_running: bool, name: str, start_cmd: str) -> None:
-    if is_running:
-        console.print(f"✅ [green]{name} is running.[/green]")
-    else:
-        console.print(
-            Panel(
-                f"[red]{name} is not running.[/red]\nRun [bold]{start_cmd}[/bold] to start it.",
-                border_style="red",
-            )
-        )
+status_app = typer.Typer(
+    help="Check status of Skyvern components.", invoke_without_command=True
+)
 
 
 def _check_port(port: int) -> bool:
-    return bool(get_pids_on_port(port))
+    """Return True if a local port is accepting connections."""
+    try:
+        with socket.create_connection(("localhost", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
 
 
-@status_app.command()
-def all() -> None:
+def _status_table() -> Table:
+    api_port = int(os.getenv("PORT", 8000))
+    ui_port = 8080
+    db_port = 5432
+
+    components = [
+        ("API server", _check_port(api_port), "skyvern run server"),
+        ("UI server", _check_port(ui_port), "skyvern run ui"),
+        ("PostgreSQL", _check_port(db_port), "skyvern init --no-postgres false"),
+    ]
+
+    table = Table(title="Skyvern Component Status")
+    table.add_column("Component", style="bold")
+    table.add_column("Running")
+    table.add_column("Start Command")
+
+    for name, running, cmd in components:
+        status = "[green]Yes[/green]" if running else "[red]No[/red]"
+        table.add_row(name, status, cmd)
+
+    return table
+
+
+@status_app.callback(invoke_without_command=True)
+def status_callback(ctx: typer.Context) -> None:
     """Show status for API server, UI, and database."""
-    console.print("[bold blue]Skyvern component status:[/bold blue]")
-    database()
-    server()
-    ui()
-
-
-@status_app.command()
-def server() -> None:
-    """Check if the Skyvern API server is running."""
-    from skyvern.config import settings
-
-    is_running = _check_port(settings.PORT)
-    _print_status(is_running, "API server", "skyvern run server")
-
-
-@status_app.command()
-def ui() -> None:
-    """Check if the Skyvern UI server is running."""
-    is_running = _check_port(8080)
-    _print_status(is_running, "UI server", "skyvern run ui")
-
-
-@status_app.command()
-def database() -> None:
-    """Check if PostgreSQL is running."""
-    is_running = _check_port(5432)
-    _print_status(is_running, "PostgreSQL", "skyvern init --no-postgres false")
+    if ctx.invoked_subcommand is None:
+        console.print(_status_table())


### PR DESCRIPTION
## Summary
- replace multiple `skyvern status` subcommands with a single command
- check ports directly using sockets instead of inspecting running PIDs
- add a table-based output showing API, UI and database status
- document `skyvern status` in the quickstart guide

## Testing
- `pre-commit` *(fails: command not found)*