### PR TITLE
Add workflow template update SDK method

### DIFF
--- a/skyvern/client/workflows/client.py
+++ b/skyvern/client/workflows/client.py
@@ -92,6 +92,85 @@ class WorkflowsClient:
             raise ApiError(status_code=_response.status_code, body=_response.text)
         raise ApiError(status_code=_response.status_code, body=_response_json)
 
+    def get_workflows(
+        self,
+        *,
+        page: typing.Optional[int] = None,
+        page_size: typing.Optional[int] = None,
+        only_saved_tasks: typing.Optional[bool] = None,
+        only_workflows: typing.Optional[bool] = None,
+        title: typing.Optional[str] = None,
+        template: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.List[Workflow]:
+        """
+        Retrieve workflows for the current organization or global templates.
+
+        Parameters
+        ----------
+        page : typing.Optional[int]
+            Page number for pagination
+
+        page_size : typing.Optional[int]
+            Number of items per page
+
+        only_saved_tasks : typing.Optional[bool]
+            Filter workflows that are saved tasks
+
+        only_workflows : typing.Optional[bool]
+            Filter workflows that are not saved tasks
+
+        title : typing.Optional[str]
+            Filter workflows by title
+
+        template : typing.Optional[bool]
+            If true, return global workflow templates
+
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration.
+
+        Returns
+        -------
+        typing.List[Workflow]
+            Successfully retrieved workflows
+        """
+        _response = self._client_wrapper.httpx_client.request(
+            "v1/workflows",
+            method="GET",
+            params={
+                "page": page,
+                "page_size": page_size,
+                "only_saved_tasks": only_saved_tasks,
+                "only_workflows": only_workflows,
+                "title": title,
+                "template": template,
+            },
+            request_options=request_options,
+        )
+        try:
+            if 200 <= _response.status_code < 300:
+                return typing.cast(
+                    typing.List[Workflow],
+                    parse_obj_as(
+                        type_=typing.List[Workflow],  # type: ignore
+                        object_=_response.json(),
+                    ),
+                )
+            if _response.status_code == 422:
+                raise UnprocessableEntityError(
+                    typing.cast(
+                        typing.Optional[typing.Any],
+                        parse_obj_as(
+                            type_=typing.Optional[typing.Any],  # type: ignore
+                            object_=_response.json(),
+                        ),
+                    )
+                )
+            _response_json = _response.json()
+        except JSONDecodeError:
+            raise ApiError(status_code=_response.status_code, body=_response.text)
+        raise ApiError(status_code=_response.status_code, body=_response_json)
+
     def update_workflow(
         self,
         workflow_id: str,
@@ -135,6 +214,72 @@ class WorkflowsClient:
         """
         _response = self._client_wrapper.httpx_client.request(
             f"v1/workflows/{jsonable_encoder(workflow_id)}",
+            method="POST",
+            json={
+                "json_definition": convert_and_respect_annotation_metadata(
+                    object_=json_definition, annotation=WorkflowCreateYamlRequest, direction="write"
+                ),
+                "yaml_definition": yaml_definition,
+            },
+            request_options=request_options,
+            omit=OMIT,
+        )
+        try:
+            if 200 <= _response.status_code < 300:
+                return typing.cast(
+                    Workflow,
+                    parse_obj_as(
+                        type_=Workflow,  # type: ignore
+                        object_=_response.json(),
+                    ),
+                )
+            if _response.status_code == 422:
+                raise UnprocessableEntityError(
+                    typing.cast(
+                        typing.Optional[typing.Any],
+                        parse_obj_as(
+                            type_=typing.Optional[typing.Any],  # type: ignore
+                            object_=_response.json(),
+                        ),
+                    )
+                )
+            _response_json = _response.json()
+        except JSONDecodeError:
+            raise ApiError(status_code=_response.status_code, body=_response.text)
+        raise ApiError(status_code=_response.status_code, body=_response_json)
+
+    def update_workflow_template(
+        self,
+        workflow_permanent_id: str,
+        *,
+        json_definition: typing.Optional[WorkflowCreateYamlRequest] = OMIT,
+        yaml_definition: typing.Optional[str] = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> Workflow:
+        """
+        Update a workflow template
+
+        Parameters
+        ----------
+        workflow_permanent_id : str
+            Permanent ID of the workflow template to update. Workflow ID starts with ``wpid_``.
+
+        json_definition : typing.Optional[WorkflowCreateYamlRequest]
+            Workflow definition in JSON format
+
+        yaml_definition : typing.Optional[str]
+            Workflow definition in YAML format
+
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration.
+
+        Returns
+        -------
+        Workflow
+            Successfully updated workflow template
+        """
+        _response = self._client_wrapper.httpx_client.request(
+            f"v1/workflows/{jsonable_encoder(workflow_permanent_id)}",
             method="POST",
             json={
                 "json_definition": convert_and_respect_annotation_metadata(
@@ -312,6 +457,85 @@ class AsyncWorkflowsClient:
             raise ApiError(status_code=_response.status_code, body=_response.text)
         raise ApiError(status_code=_response.status_code, body=_response_json)
 
+    async def get_workflows(
+        self,
+        *,
+        page: typing.Optional[int] = None,
+        page_size: typing.Optional[int] = None,
+        only_saved_tasks: typing.Optional[bool] = None,
+        only_workflows: typing.Optional[bool] = None,
+        title: typing.Optional[str] = None,
+        template: typing.Optional[bool] = None,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> typing.List[Workflow]:
+        """
+        Retrieve workflows for the current organization or global templates.
+
+        Parameters
+        ----------
+        page : typing.Optional[int]
+            Page number for pagination
+
+        page_size : typing.Optional[int]
+            Number of items per page
+
+        only_saved_tasks : typing.Optional[bool]
+            Filter workflows that are saved tasks
+
+        only_workflows : typing.Optional[bool]
+            Filter workflows that are not saved tasks
+
+        title : typing.Optional[str]
+            Filter workflows by title
+
+        template : typing.Optional[bool]
+            If true, return global workflow templates
+
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration.
+
+        Returns
+        -------
+        typing.List[Workflow]
+            Successfully retrieved workflows
+        """
+        _response = await self._client_wrapper.httpx_client.request(
+            "v1/workflows",
+            method="GET",
+            params={
+                "page": page,
+                "page_size": page_size,
+                "only_saved_tasks": only_saved_tasks,
+                "only_workflows": only_workflows,
+                "title": title,
+                "template": template,
+            },
+            request_options=request_options,
+        )
+        try:
+            if 200 <= _response.status_code < 300:
+                return typing.cast(
+                    typing.List[Workflow],
+                    parse_obj_as(
+                        type_=typing.List[Workflow],  # type: ignore
+                        object_=_response.json(),
+                    ),
+                )
+            if _response.status_code == 422:
+                raise UnprocessableEntityError(
+                    typing.cast(
+                        typing.Optional[typing.Any],
+                        parse_obj_as(
+                            type_=typing.Optional[typing.Any],  # type: ignore
+                            object_=_response.json(),
+                        ),
+                    )
+                )
+            _response_json = _response.json()
+        except JSONDecodeError:
+            raise ApiError(status_code=_response.status_code, body=_response.text)
+        raise ApiError(status_code=_response.status_code, body=_response_json)
+
     async def update_workflow(
         self,
         workflow_id: str,
@@ -363,6 +587,72 @@ class AsyncWorkflowsClient:
         """
         _response = await self._client_wrapper.httpx_client.request(
             f"v1/workflows/{jsonable_encoder(workflow_id)}",
+            method="POST",
+            json={
+                "json_definition": convert_and_respect_annotation_metadata(
+                    object_=json_definition, annotation=WorkflowCreateYamlRequest, direction="write"
+                ),
+                "yaml_definition": yaml_definition,
+            },
+            request_options=request_options,
+            omit=OMIT,
+        )
+        try:
+            if 200 <= _response.status_code < 300:
+                return typing.cast(
+                    Workflow,
+                    parse_obj_as(
+                        type_=Workflow,  # type: ignore
+                        object_=_response.json(),
+                    ),
+                )
+            if _response.status_code == 422:
+                raise UnprocessableEntityError(
+                    typing.cast(
+                        typing.Optional[typing.Any],
+                        parse_obj_as(
+                            type_=typing.Optional[typing.Any],  # type: ignore
+                            object_=_response.json(),
+                        ),
+                    )
+                )
+            _response_json = _response.json()
+        except JSONDecodeError:
+            raise ApiError(status_code=_response.status_code, body=_response.text)
+        raise ApiError(status_code=_response.status_code, body=_response_json)
+
+    async def update_workflow_template(
+        self,
+        workflow_permanent_id: str,
+        *,
+        json_definition: typing.Optional[WorkflowCreateYamlRequest] = OMIT,
+        yaml_definition: typing.Optional[str] = OMIT,
+        request_options: typing.Optional[RequestOptions] = None,
+    ) -> Workflow:
+        """
+        Update a workflow template
+
+        Parameters
+        ----------
+        workflow_permanent_id : str
+            Permanent ID of the workflow template to update. Workflow ID starts with ``wpid_``.
+
+        json_definition : typing.Optional[WorkflowCreateYamlRequest]
+            Workflow definition in JSON format
+
+        yaml_definition : typing.Optional[str]
+            Workflow definition in YAML format
+
+        request_options : typing.Optional[RequestOptions]
+            Request-specific configuration.
+
+        Returns
+        -------
+        Workflow
+            Successfully updated workflow template
+        """
+        _response = await self._client_wrapper.httpx_client.request(
+            f"v1/workflows/{jsonable_encoder(workflow_permanent_id)}",
             method="POST",
             json={
                 "json_definition": convert_and_respect_annotation_metadata(

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1355,11 +1355,21 @@ async def get_workflow_run(
         "x-fern-sdk-method-name": "get_workflows",
     },
 )
+@base_router.get(
+    "/workflows",
+    response_model=list[Workflow],
+    tags=["Workflows"],
+    openapi_extra={
+        "x-fern-sdk-group-name": "workflows",
+        "x-fern-sdk-method-name": "get_workflows",
+    },
+)
 @legacy_base_router.get(
     "/workflows/",
     response_model=list[Workflow],
     include_in_schema=False,
 )
+@base_router.get("/workflows/", response_model=list[Workflow], include_in_schema=False)
 async def get_workflows(
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1),
@@ -1413,11 +1423,21 @@ async def get_workflows(
         "x-fern-sdk-method-name": "get_workflow_templates",
     },
 )
+@base_router.get(
+    "/workflows/templates",
+    response_model=list[Workflow],
+    tags=["Workflows"],
+    openapi_extra={
+        "x-fern-sdk-group-name": "workflows",
+        "x-fern-sdk-method-name": "get_workflow_templates",
+    },
+)
 @legacy_base_router.get(
     "/workflows/templates/",
     response_model=list[Workflow],
     include_in_schema=False,
 )
+@base_router.get("/workflows/templates/", response_model=list[Workflow], include_in_schema=False)
 async def get_workflow_templates() -> list[Workflow]:
     global_workflows_permanent_ids = await app.STORAGE.retrieve_global_workflows()
 


### PR DESCRIPTION
## Summary
- expose `update_workflow_template` for workflows in the SDK
- allow updating workflow templates by permanent ID
- add SDK interfaces to list workflows and templates
- expose public `/v1/workflows` and `/v1/workflows/templates` API paths

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
