### PR TITLE
Update frontend API endpoints

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -5,8 +5,8 @@ COPY ./skyvern-frontend /app
 COPY ./entrypoint-skyvernui.sh /app/entrypoint-skyvernui.sh
 RUN npm install
 
-ENV VITE_API_BASE_URL=http://localhost:8000/api/v1
-ENV VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
+ENV VITE_API_BASE_URL=http://localhost:8000/v1
+ENV VITE_WSS_BASE_URL=ws://localhost:8000/v1
 ENV VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
 
 CMD [ "/bin/bash", "/app/entrypoint-skyvernui.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,9 +127,9 @@ services:
     #   A route for the API: api.yourdomain.com -> localhost:8000
     #   A route for the UI: yourdomain.com -> localhost:8080
     #   A route for the artifact API: artifact.yourdomain.com -> localhost:9090 (maybe not needed)
-      - VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
+      - VITE_WSS_BASE_URL=ws://localhost:8000/v1
     #   - VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
-    #   - VITE_API_BASE_URL=http://localhost:8000/api/v1
+    #   - VITE_API_BASE_URL=http://localhost:8000/v1
     #   - VITE_SKYVERN_API_KEY=<get this from "settings" in the Skyvern UI>
     depends_on:
       skyvern:

--- a/entrypoint-skyvern.sh
+++ b/entrypoint-skyvern.sh
@@ -12,7 +12,7 @@ if [ ! -f ".streamlit/secrets.toml" ]; then
     org_output=$(python scripts/create_organization.py Skyvern-Open-Source)
     api_token=$(echo "$org_output" | awk '/token=/{gsub(/.*token='\''|'\''.*/, ""); print}')
     # Update the secrets-open-source.toml file
-    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://skyvern:8000/api/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
+    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://skyvern:8000/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
     echo ".streamlit/secrets.toml file updated with organization details."
 fi
 

--- a/scripts/test_persistent_browsers.py
+++ b/scripts/test_persistent_browsers.py
@@ -11,7 +11,7 @@ from skyvern.forge.sdk.schemas.tasks import TaskRequest
 load_dotenv("./skyvern-frontend/.env")
 API_KEY = os.getenv("VITE_SKYVERN_API_KEY")
 
-API_BASE_URL = "http://localhost:8000/api/v1"
+API_BASE_URL = "http://localhost:8000/v1"
 HEADERS = {"x-api-key": API_KEY, "Content-Type": "application/json"}
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -373,7 +373,7 @@ create_organization() {
     fi
 
     # Update the secrets-open-source.toml file
-    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://127.0.0.1:8000/api/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
+    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://127.0.0.1:8000/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
     echo ".streamlit/secrets.toml file updated with organization details."
 
     # Check if skyvern-frontend/.env exists and back it up

--- a/skyvern-frontend/.env.example
+++ b/skyvern-frontend/.env.example
@@ -1,11 +1,11 @@
-VITE_API_BASE_URL=http://localhost:8000/api/v1
+VITE_API_BASE_URL=http://localhost:8000/v1
 
 # server to load artifacts from file URIs
 VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
 
 # websocket
-# VITE_WSS_BASE_URL=wss://api-staging.skyvern.com/api/v1
-VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
+# VITE_WSS_BASE_URL=wss://api-staging.skyvern.com/v1
+VITE_WSS_BASE_URL=ws://localhost:8000/v1
 
 # your api key - for x-api-key header
 VITE_SKYVERN_API_KEY=YOUR_API_KEY

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -128,7 +128,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
       return client.post<
         ReturnType<typeof createTaskRequestObject>,
         { data: { task_id: string } }
-      >("/tasks", taskRequest, {
+      >("/run/tasks", taskRequest, {
         ...(includeOverrideHeader && {
           headers: {
             "x-max-steps-override": formValues.maxStepsOverride,

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -22,10 +22,13 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
 
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
-      const client = await getClient(credentialGetter, "v2");
-      return client.post<{ user_prompt: string }, { data: TaskV2 }>("/tasks", {
-        user_prompt: prompt,
-      });
+      const client = await getClient(credentialGetter);
+      return client.post<{ user_prompt: string }, { data: TaskV2 }>(
+        "/run/tasks",
+        {
+          user_prompt: prompt,
+        },
+      );
     },
     onSuccess: (response) => {
       toast({

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -158,9 +158,9 @@ function PromptBox() {
 
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
-      const client = await getClient(credentialGetter, "v2");
+      const client = await getClient(credentialGetter);
       return client.post<Createv2TaskRequest, { data: TaskV2 }>(
-        "/tasks",
+        "/run/tasks",
         {
           user_prompt: prompt,
           webhook_callback_url: webhookCallbackUrl,

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -163,7 +163,7 @@ function SavedTaskForm({ initialValues }: Props) {
           return client.post<
             ReturnType<typeof createTaskRequestObject>,
             { data: { task_id: string } }
-          >("/tasks", taskRequest, {
+          >("/run/tasks", taskRequest, {
             ...(includeOverrideHeader && {
               headers: {
                 "x-max-steps-override":

--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -65,7 +65,7 @@ function TaskDetails() {
       queryFn: async () => {
         const client = await getClient(credentialGetter);
         return client
-          .get(`/workflows/runs/${task?.workflow_run_id}`)
+          .get(`/runs/${task?.workflow_run_id}`)
           .then((response) => response.data);
       },
       enabled: !!task?.workflow_run_id,
@@ -87,7 +87,7 @@ function TaskDetails() {
     mutationFn: async () => {
       const client = await getClient(credentialGetter);
       return client
-        .post(`/tasks/${taskId}/cancel`)
+        .post(`/runs/${taskId}/cancel`)
         .then((response) => response.data);
     },
     onSuccess: () => {

--- a/skyvern-frontend/src/routes/tasks/detail/hooks/useTaskQuery.ts
+++ b/skyvern-frontend/src/routes/tasks/detail/hooks/useTaskQuery.ts
@@ -14,7 +14,7 @@ function useTaskQuery({ id }: Props) {
     queryKey: ["task", id],
     queryFn: async () => {
       const client = await getClient(credentialGetter);
-      return client.get(`/tasks/${id}`).then((response) => response.data);
+      return client.get(`/runs/${id}`).then((response) => response.data);
     },
     enabled: !!id,
     refetchInterval: (query) => {

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -123,9 +123,9 @@ function RunWorkflowForm({
       const client = await getClient(credentialGetter);
       const body = getRunWorkflowRequestBody(values, workflowParameters);
       return client.post<
-        RunWorkflowRequestBody,
+        RunWorkflowRequestBody & { workflow_id: string },
         { data: { workflow_run_id: string } }
-      >(`/workflows/${workflowPermanentId}/run`, body);
+      >("/run/workflows", { ...body, workflow_id: workflowPermanentId! });
     },
     onSuccess: (response) => {
       toast({
@@ -345,8 +345,8 @@ function RunWorkflowForm({
 
               const curl = fetchToCurl({
                 method: "POST",
-                url: `${apiBaseUrl}/workflows/${workflowPermanentId}/run`,
-                body,
+                url: `${apiBaseUrl}/run/workflows`,
+                body: { ...body, workflow_id: workflowPermanentId! },
                 headers: {
                   "Content-Type": "application/json",
                   "x-api-key": apiCredential ?? "<your-api-key>",

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -64,7 +64,7 @@ function WorkflowRun() {
     mutationFn: async () => {
       const client = await getClient(credentialGetter);
       return client
-        .post(`/workflows/runs/${workflowRunId}/cancel`)
+        .post(`/runs/${workflowRunId}/cancel`)
         .then((response) => response.data);
     },
     onSuccess: () => {

--- a/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunQuery.ts
@@ -26,7 +26,7 @@ function useWorkflowRunQuery() {
         params.set("template", "true");
       }
       return client
-        .get(`/workflows/${workflowPermanentId}/runs/${workflowRunId}`, {
+        .get(`/runs/${workflowRunId}`, {
           params,
         })
         .then((response) => response.data);

--- a/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunTimelineQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunTimelineQuery.ts
@@ -25,10 +25,7 @@ function useWorkflowRunTimelineQuery() {
         params.set("template", "true");
       }
       return client
-        .get(
-          `/workflows/${workflowPermanentId}/runs/${workflowRunId}/timeline`,
-          { params },
-        )
+        .get(`/runs/${workflowRunId}/timeline`, { params })
         .then((response) => response.data);
     },
     refetchInterval:

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
@@ -45,7 +45,7 @@ function WorkflowRunStream() {
         socket.close();
       }
       socket = new WebSocket(
-        `${wssBaseUrl}/stream/workflow_runs/${workflowRunId}${credential}`,
+        `${wssBaseUrl}/stream/runs/${workflowRunId}${credential}`,
       );
       // Listen for messages
       socket.addEventListener("message", (event) => {


### PR DESCRIPTION
## Summary
- update env defaults for new `/v1` API path
- adjust Dockerfile and compose configuration
- rewire workflow run requests to `/run/workflows`
- rewire task creation to `/run/tasks`
- update run and cancel requests to new `/runs` endpoints

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*