### PR TITLE
Fix CredentialItem import in PasswordManagerService

### DIFF
--- a/skyvern/forge/sdk/services/password_manager.py
+++ b/skyvern/forge/sdk/services/password_manager.py
@@ -1,21 +1,24 @@
 from .bitwarden import BitwardenService
 from .onepassword import OnePasswordService
-from .. import schemas
+from skyvern.forge.sdk.schemas.credentials import (
+    CredentialItem,
+    CredentialType,
+    PasswordCredential,
+)
 from skyvern.config import settings
+
 
 class PasswordManagerService:
     @staticmethod
-    async def get_credential_item(item_id: str) -> schemas.CredentialItem:
+    async def get_credential_item(item_id: str) -> CredentialItem:
         if settings.PASSWORD_MANAGER.lower() == "onepassword":
             token = settings.ONEPASSWORD_TOKEN or ""
             vault_id = settings.ONEPASSWORD_VAULT or ""
-            return schemas.CredentialItem(
+            return CredentialItem(
                 item_id=item_id,
-                credential_type=schemas.CredentialType.PASSWORD,
+                credential_type=CredentialType.PASSWORD,
                 name=item_id,
-                credential=schemas.PasswordCredential(
-                    **await OnePasswordService.get_login_item(token, vault_id, item_id)
-                ),
+                credential=PasswordCredential(**await OnePasswordService.get_login_item(token, vault_id, item_id)),
             )
         else:
             return await BitwardenService.get_credential_item(item_id)


### PR DESCRIPTION
## Summary
- adjust imports in `PasswordManagerService` to reference credential schemas directly

## Testing
- `ruff check skyvern/forge/sdk/services/password_manager.py`
- `ruff format skyvern/forge/sdk/services/password_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*