### PR TITLE
Add 1Password option for credential parameters

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -84,7 +84,11 @@ import {
   nodeAdderNode,
   startNode,
 } from "./workflowEditorUtils";
-import { parameterIsBitwardenCredential, ParametersState } from "./types";
+import {
+  parameterIsBitwardenCredential,
+  parameterIsOnePasswordCredential,
+  ParametersState,
+} from "./types";
 import { useAutoPan } from "./useAutoPan";
 
 function convertToParametersYAML(
@@ -149,14 +153,21 @@ function convertToParametersYAML(
           BITWARDEN_MASTER_PASSWORD_AWS_SECRET_KEY,
       };
     } else {
-      if (parameterIsBitwardenCredential(parameter)) {
+      if (
+        parameterIsBitwardenCredential(parameter) ||
+        parameterIsOnePasswordCredential(parameter)
+      ) {
         return {
           parameter_type: WorkflowParameterTypes.Bitwarden_Login_Credential,
           key: parameter.key,
           description: parameter.description || null,
-          bitwarden_collection_id: parameter.collectionId,
+          bitwarden_collection_id: parameterIsBitwardenCredential(parameter)
+            ? parameter.collectionId
+            : null,
           bitwarden_item_id: parameter.itemId,
-          url_parameter_key: parameter.urlParameterKey,
+          url_parameter_key: parameterIsBitwardenCredential(parameter)
+            ? parameter.urlParameterKey
+            : null,
           bitwarden_client_id_aws_secret_key:
             BITWARDEN_CLIENT_ID_AWS_SECRET_KEY,
           bitwarden_client_secret_aws_secret_key:

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -139,6 +139,17 @@ function WorkflowEditor() {
                   description: parameter.description,
                 };
               } else {
+                const isOnePassword =
+                  parameter.bitwarden_collection_id === null &&
+                  parameter.url_parameter_key === null;
+                if (isOnePassword) {
+                  return {
+                    key: parameter.key,
+                    parameterType: WorkflowEditorParameterTypes.Credential,
+                    itemId: parameter.bitwarden_item_id,
+                    description: parameter.description,
+                  };
+                }
                 return {
                   key: parameter.key,
                   parameterType: WorkflowEditorParameterTypes.Credential,

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
@@ -79,9 +79,11 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
     string | undefined
   >(undefined);
 
-  const [credentialType, setCredentialType] = useState<"bitwarden" | "skyvern">(
-    "skyvern",
-  );
+  const [credentialType, setCredentialType] = useState<
+    "bitwarden" | "skyvern" | "onepassword"
+  >("skyvern");
+
+  const [onePasswordItemId, setOnePasswordItemId] = useState("");
 
   const [identityKey, setIdentityKey] = useState("");
   const [identityFields, setIdentityFields] = useState("");
@@ -199,11 +201,14 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
             <SwitchBar
               value={credentialType}
               onChange={(value) => {
-                setCredentialType(value as "bitwarden" | "skyvern");
+                setCredentialType(
+                  value as "bitwarden" | "skyvern" | "onepassword"
+                );
               }}
               options={[
                 { label: "Skyvern", value: "skyvern" },
                 { label: "Bitwarden", value: "bitwarden" },
+                { label: "1Password", value: "onepassword" },
               ]}
             />
           )}
@@ -235,6 +240,15 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
                 />
               </div>
             </>
+          )}
+          {type === "credential" && credentialType === "onepassword" && (
+            <div className="space-y-1">
+              <Label className="text-xs text-slate-300">Item ID</Label>
+              <Input
+                value={onePasswordItemId}
+                onChange={(e) => setOnePasswordItemId(e.target.value)}
+              />
+            </div>
           )}
           {type === "context" && (
             <div className="space-y-1">
@@ -375,6 +389,22 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
                         : bitwardenLoginCredentialItemId,
                     urlParameterKey:
                       urlParameterKey === "" ? null : urlParameterKey,
+                    description,
+                  });
+                }
+                if (type === "credential" && credentialType === "onepassword") {
+                  if (!onePasswordItemId) {
+                    toast({
+                      variant: "destructive",
+                      title: "Failed to save parameter",
+                      description: "Item ID is required",
+                    });
+                    return;
+                  }
+                  onSave({
+                    key,
+                    parameterType: "credential",
+                    itemId: onePasswordItemId,
                     description,
                   });
                 }

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
@@ -78,8 +78,17 @@ function WorkflowParameterEditPanel({
   const isSkyvernCredential =
     initialValues.parameterType === "credential" &&
     parameterIsSkyvernCredential(initialValues);
-  const [credentialType, setCredentialType] = useState<"bitwarden" | "skyvern">(
-    isBitwardenCredential ? "bitwarden" : "skyvern",
+  const isOnePasswordCredential =
+    initialValues.parameterType === "credential" &&
+    parameterIsOnePasswordCredential(initialValues);
+  const [credentialType, setCredentialType] = useState<
+    "bitwarden" | "skyvern" | "onepassword"
+  >(
+    isBitwardenCredential
+      ? "bitwarden"
+      : isOnePasswordCredential
+      ? "onepassword"
+      : "skyvern",
   );
   const [urlParameterKey, setUrlParameterKey] = useState(
     isBitwardenCredential ? initialValues.urlParameterKey ?? "" : "",
@@ -146,6 +155,9 @@ function WorkflowParameterEditPanel({
 
   const [bitwardenLoginCredentialItemId, setBitwardenLoginCredentialItemId] =
     useState(isBitwardenCredential ? initialValues.itemId ?? "" : "");
+  const [onePasswordItemId, setOnePasswordItemId] = useState(
+    isOnePasswordCredential ? initialValues.itemId ?? "" : ""
+  );
 
   return (
     <ScrollArea>
@@ -256,11 +268,14 @@ function WorkflowParameterEditPanel({
             <SwitchBar
               value={credentialType}
               onChange={(value) => {
-                setCredentialType(value as "bitwarden" | "skyvern");
+                setCredentialType(
+                  value as "bitwarden" | "skyvern" | "onepassword"
+                );
               }}
               options={[
                 { label: "Skyvern", value: "skyvern" },
                 { label: "Bitwarden", value: "bitwarden" },
+                { label: "1Password", value: "onepassword" },
               ]}
             />
           )}
@@ -292,6 +307,15 @@ function WorkflowParameterEditPanel({
                 />
               </div>
             </>
+          )}
+          {type === "credential" && credentialType === "onepassword" && (
+            <div className="space-y-1">
+              <Label className="text-xs text-slate-300">Item ID</Label>
+              <Input
+                value={onePasswordItemId}
+                onChange={(e) => setOnePasswordItemId(e.target.value)}
+              />
+            </div>
           )}
           {type === "context" && (
             <div className="space-y-1">
@@ -427,6 +451,22 @@ function WorkflowParameterEditPanel({
                     urlParameterKey:
                       urlParameterKey === "" ? null : urlParameterKey,
                     collectionId: collectionId === "" ? null : collectionId,
+                    description,
+                  });
+                }
+                if (type === "credential" && credentialType === "onepassword") {
+                  if (!onePasswordItemId) {
+                    toast({
+                      variant: "destructive",
+                      title: "Failed to save parameter",
+                      description: "Item ID is required",
+                    });
+                    return;
+                  }
+                  onSave({
+                    key,
+                    parameterType: "credential",
+                    itemId: onePasswordItemId,
                     description,
                   });
                 }

--- a/skyvern-frontend/src/routes/workflows/editor/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/types.ts
@@ -16,6 +16,13 @@ export type SkyvernCredential = {
   credentialId: string;
 };
 
+export type OnePasswordCredential = {
+  key: string;
+  description?: string | null;
+  parameterType: "credential";
+  itemId: string | null;
+};
+
 export function parameterIsBitwardenCredential(
   parameter: CredentialParameterState,
 ): parameter is BitwardenLoginCredential {
@@ -28,9 +35,20 @@ export function parameterIsSkyvernCredential(
   return "credentialId" in parameter;
 }
 
+export function parameterIsOnePasswordCredential(
+  parameter: CredentialParameterState,
+): parameter is OnePasswordCredential {
+  return (
+    "itemId" in parameter &&
+    !("collectionId" in parameter) &&
+    !("credentialId" in parameter)
+  );
+}
+
 export type CredentialParameterState =
   | BitwardenLoginCredential
-  | SkyvernCredential;
+  | SkyvernCredential
+  | OnePasswordCredential;
 
 export type ParametersState = Array<
   | {


### PR DESCRIPTION
## Summary
- add OnePasswordCredential type and helpers
- allow selecting 1Password when adding/editing credential parameters
- update FlowRenderer conversion logic
- parse existing parameters as 1Password when collection & url key are absent

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find modules during TypeScript compile)*