### PR TITLE
Include .env in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 **/.venv
 **/.vscode
 *.env*
+!/.env
 # Streamlit ignores
 **/secrets*.toml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11 as requirements-stage
+# Run `skyvern init llm` before building to generate the .env file
 
 WORKDIR /tmp
 RUN pip install poetry

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ skyvern status
 1. Make sure you have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running on your machine
 1. Make sure you don't have postgres running locally (Run `docker ps` to check)
 1. Clone the repository and navigate to the root directory
+1. Run `skyvern init llm` to generate a `.env` file. This will be copied into the Docker image.
 1. Fill in the LLM provider key on the [docker-compose.yml](./docker-compose.yml). *If you want to run Skyvern on a remote server, make sure you set the correct server ip for the UI container in [docker-compose.yml](./docker-compose.yml).*
 2. Run the following command via the commandline:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
   skyvern:
     image: public.ecr.aws/skyvern/skyvern:latest
     restart: on-failure
+    env_file:
+      - .env
     # comment out if you want to externally call skyvern API
     ports:
       - 8000:8000


### PR DESCRIPTION
## Summary
- copy `.env` into Docker image
- load env vars from `.env` when running Docker Compose
- note to run `skyvern init llm` before building

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*