### PR TITLE
Add cron scheduler settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,24 @@ skyvern status
 If you encounter any database related errors while using Docker to run Skyvern, check which Postgres container is running with `docker ps`.
 
 
+## Cron Workflows
+
+Skyvern can run workflows on a recurring schedule. Enable this feature by adding the following variables to your `.env` file:
+
+```bash
+ENABLE_CRON_WORKFLOWS=true
+DEFAULT_CRON_TIMEZONE=UTC
+```
+
+`DEFAULT_CRON_TIMEZONE` sets the timezone used when cron expressions omit one. Use any valid IANA timezone string such as `UTC` or `America/Los_Angeles`.
+
+Start the scheduler alongside the API server with:
+
+```bash
+skyvern run scheduler
+```
+
+
 # How it works
 Skyvern was inspired by the Task-Driven autonomous agent design popularized by [BabyAGI](https://github.com/yoheinakajima/babyagi) and [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) -- with one major bonus: we give Skyvern the ability to interact with websites using browser automation libraries like [Playwright](https://playwright.dev/).
 

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -80,6 +80,10 @@ class Settings(BaseSettings):
     BROWSER_WIDTH: int = 1920
     BROWSER_HEIGHT: int = 1080
 
+    # cron workflow settings
+    ENABLE_CRON_WORKFLOWS: bool = False
+    DEFAULT_CRON_TIMEZONE: str = "UTC"
+
     # Add extension folders name here to load extension in your browser
     EXTENSIONS_BASE_PATH: str = "./extensions"
     EXTENSIONS: list[str] = []


### PR DESCRIPTION
## Summary
- add ENABLE_CRON_WORKFLOWS and DEFAULT_CRON_TIMEZONE to config
- document cron workflows in README

## Testing
- `pre-commit run --all-files` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a6a2585c0832495829ffec6e51f4c