### PR TITLE
Add queue time to run API response

### DIFF
--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -355,6 +355,10 @@ class BaseRunResponse(BaseModel):
         description="URL to the application UI where the run can be viewed",
         examples=["https://app.skyvern.com/tasks/tsk_123", "https://app.skyvern.com/workflows/wpid_123/wr_123"],
     )
+    queue_time_seconds: float | None = Field(
+        default=None,
+        description="Time in seconds the run spent in the task queue before execution",
+    )
 
 
 class TaskRunResponse(BaseRunResponse):

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1593,7 +1593,7 @@ async def _summarize_task_v2(
     )
 
 
-async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
+async def build_task_v2_run_response(task_v2: TaskV2, queue_time_seconds: float | None = None) -> TaskRunResponse:
     """Build TaskRunResponse object for webhook backward compatibility."""
     from skyvern.services import workflow_service
 
@@ -1629,6 +1629,7 @@ async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
         screenshot_urls=workflow_run_resp.screenshot_urls if workflow_run_resp else None,
         downloaded_files=workflow_run_resp.downloaded_files if workflow_run_resp else None,
         app_url=app_url,
+        queue_time_seconds=queue_time_seconds,
         run_request=TaskRunRequest(
             engine=RunEngine.skyvern_v2,
             prompt=task_v2.prompt or "",
@@ -1661,7 +1662,13 @@ async def send_task_v2_webhook(task_v2: TaskV2) -> None:
         return
     try:
         # build the task v2 response with backward compatible data
-        task_run_response = await build_task_v2_run_response(task_v2)
+        thoughts = await app.DATABASE.get_thoughts(
+            task_v2_id=task_v2.observer_cruise_id, organization_id=organization_id
+        )
+        queue_time_seconds = None
+        if thoughts:
+            queue_time_seconds = (thoughts[0].created_at - task_v2.created_at).total_seconds()
+        task_run_response = await build_task_v2_run_response(task_v2, queue_time_seconds)
         task_run_response_json = task_run_response.model_dump_json(exclude={"run_request"})
         payload_json = task_v2.model_dump_json(by_alias=True)
         payload_dict = json.loads(payload_json)


### PR DESCRIPTION
## Summary
- expose `queue_time_seconds` in `BaseRunResponse`
- compute queue time when building run responses for tasks
- include queue time when building task V2 responses and sending webhooks

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a711083f883248693afb52819a351